### PR TITLE
smartly manage connection to OBS

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,13 @@ export const server = new McpServer({
 });
 
 export let serverConnected = false;
+export let obsConnected = false;
+let reconnectInterval: NodeJS.Timeout | null = null;
+let connectionCheckInterval: NodeJS.Timeout | null = null;
+let reconnectAttempts = 0;
+const RECONNECT_INTERVAL = 5000; // 5 seconds (reduced from 10)
+const CONNECTION_CHECK_INTERVAL = 1000; // 1 second (reduced from 5)
+const MAX_BACKOFF_INTERVAL = 30000; // Max 30 seconds between attempts
 
 const logger = {
   log: (message: string) => console.error(message),
@@ -23,10 +30,99 @@ const logger = {
   debug: (message: string) => console.error(message),
 };
 
+// Function to attempt OBS connection
+async function attemptOBSConnection(): Promise<void> {
+  try {
+    logger.log("Attempting to connect to OBS WebSocket...");
+    
+    // Set a timeout for the connection attempt
+    const connectionPromise = obsClient.connect();
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error("Connection timeout after 10 seconds")), 10000);
+    });
+    
+    await Promise.race([connectionPromise, timeoutPromise]);
+    logger.log("Connected to OBS WebSocket server");
+    obsConnected = true;
+    reconnectAttempts = 0;
+    
+    // Clear any existing reconnect interval
+    if (reconnectInterval) {
+      clearInterval(reconnectInterval);
+      reconnectInterval = null;
+    }
+    
+    // Set up disconnect handler to trigger reconnection
+    obsClient.on('disconnected', () => {
+      logger.log("OBS WebSocket disconnected, will attempt to reconnect...");
+      obsConnected = false;
+      startReconnectionTimer();
+    });
+    
+  } catch (obsError) {
+    const errorMessage = obsError instanceof Error ? obsError.message : String(obsError);
+    logger.error(`Failed to connect to OBS WebSocket: ${errorMessage}`);
+    
+    if (reconnectAttempts === 0) {
+      logger.error("The server will continue running without OBS connection.");
+      logger.error("Make sure OBS Studio is running with WebSocket enabled on port 4455");
+      logger.error("You can also set OBS_WEBSOCKET_URL and OBS_WEBSOCKET_PASSWORD environment variables");
+      logger.error("The server will attempt to reconnect every 5 seconds...");
+    }
+    
+    obsConnected = false;
+    reconnectAttempts++;
+    
+    // Use exponential backoff with a maximum interval
+    const backoffInterval = Math.min(RECONNECT_INTERVAL * Math.pow(1.5, Math.min(reconnectAttempts, 3)), MAX_BACKOFF_INTERVAL);
+    startReconnectionTimer(backoffInterval);
+  }
+}
+
+// Function to start reconnection timer with backoff
+function startReconnectionTimer(interval?: number): void {
+  if (reconnectInterval) {
+    clearInterval(reconnectInterval);
+  }
+  
+  const checkInterval = interval || RECONNECT_INTERVAL;
+  logger.debug(`Will retry connection in ${checkInterval / 1000} seconds...`);
+  
+  reconnectInterval = setInterval(async () => {
+    if (!obsConnected) {
+      logger.log(`Reconnection attempt ${reconnectAttempts + 1}...`);
+      await attemptOBSConnection();
+    }
+  }, checkInterval);
+}
+
+// Function to start periodic connection checking
+function startConnectionCheckTimer(): void {
+  if (connectionCheckInterval) {
+    clearInterval(connectionCheckInterval);
+  }
+  
+  connectionCheckInterval = setInterval(async () => {
+    // Only check if we're not currently connected
+    if (!obsConnected) {
+      logger.debug("Checking if OBS is now available...");
+      try {
+        // Try a quick connection test
+        await attemptOBSConnection();
+        if (obsConnected) {
+          logger.log("🎉 OBS became available and connection was established!");
+        }
+      } catch (error) {
+        // Silently fail - this is just a check, not a retry
+        logger.debug("OBS still not available");
+      }
+    }
+  }, CONNECTION_CHECK_INTERVAL);
+}
+
 // Set up server startup logic
 export async function startServer() {
   try {
-
     // Initialize all tools with the OBS client
     await tools.initialize(server, obsClient);
     logger.log("Initialized MCP tools");
@@ -38,16 +134,32 @@ export async function startServer() {
 
     serverConnected = true;
 
-    // Connect to OBS WebSocket
-    logger.log("Connecting to OBS WebSocket...");
-    await obsClient.connect();
-    logger.log("Connected to OBS WebSocket server");
+    // Try to connect to OBS WebSocket (but don't fail if it's not available)
+    await attemptOBSConnection();
+
+    // Start the periodic connection check timer
+    startConnectionCheckTimer();
 
     // Set up graceful shutdown
     process.on("SIGINT", handleShutdown);
     process.on("SIGTERM", handleShutdown);
+    
+    logger.log("Server startup complete");
+    
+    // Log connection status
+    if (obsConnected) {
+      logger.log("✅ OBS WebSocket: Connected");
+    } else {
+      logger.log("❌ OBS WebSocket: Disconnected (will retry automatically)");
+      logger.log("💡 The server will also check every 1 second if OBS becomes available");
+    }
+    
   } catch (error) {
-    logger.error(`Error starting server: ${error instanceof Error ? error.message : String(error)}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error(`Error starting server: ${errorMessage}`);
+    if (error instanceof Error && error.stack) {
+      logger.error(`Stack trace: ${error.stack}`);
+    }
     process.exit(1);
   }
 }
@@ -55,7 +167,23 @@ export async function startServer() {
 // Handle graceful shutdown
 async function handleShutdown() {
   logger.log("Shutting down...");
-  obsClient.disconnect();
+  
+  // Clear all intervals
+  if (reconnectInterval) {
+    clearInterval(reconnectInterval);
+    reconnectInterval = null;
+  }
+  
+  if (connectionCheckInterval) {
+    clearInterval(connectionCheckInterval);
+    connectionCheckInterval = null;
+  }
+  
+  // Disconnect from OBS if connected
+  if (obsConnected) {
+    obsClient.disconnect();
+  }
+  
   process.exit(0);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.js"]
 }


### PR DESCRIPTION
Hey @royshil 👋🏼 

Sometimes when I run Claude I get a message about the OBS server failing.

This happens because the MCP server quietly falls over when the OBS desktop app is not running.

This PR updates to the server so it can gracefully handle connectivity to OBS, whether the app is running or not.

How it works:

- Server starts without OBS and continues running
- Checks periodically second if OBS becomes available
- Attempts reconnection on an interval with smart backoff
- Automatically connects when OBS starts up

Changes:

- Server continues running without OBS
- Auto-reconnects when OBS becomes available
- Added status tools (`obs-get-status`, `obs-test-connection`)
- Improved error handling and logging

Here it is in action:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a222980e-7bf9-4b76-b545-e698303c469e" />
